### PR TITLE
给 `romanWord` 补充 `display: flex` 属性

### DIFF
--- a/packages/core/src/styles/lyric-player.module.css
+++ b/packages/core/src/styles/lyric-player.module.css
@@ -108,7 +108,7 @@
 	.romanWord {
 		font-size: 0.5em;
 		line-height: 1em;
-        display: flex;
+		display: flex;
 	}
 
 	& > span,


### PR DESCRIPTION
让对唱视角的逐词音译与主歌词部分左对齐。

---

修改前：
<img width="2560" height="1239" alt="image" src="https://github.com/user-attachments/assets/17f78a87-43b9-444a-a2ae-8ada57a945bf" />

修改后：
<img width="2560" height="1239" alt="image" src="https://github.com/user-attachments/assets/8dccc52d-3490-4b5b-bd0f-0db24544b539" />